### PR TITLE
Add example application translation

### DIFF
--- a/book/chapter-06-example-application.md
+++ b/book/chapter-06-example-application.md
@@ -31,7 +31,76 @@ const fooProp = prop('foo');
 As far as I know, this is a limitation of the type system.
 {% endhint %}
 
+A translation of the example from the book using `fp-ts`:
 
+{% tabs %}
+{% tab title="book" %}
+```javascript
+const Impure = {
+  getJSON: curry((callback, url) => $.getJSON(url, callback)),
+  setHtml: curry((sel, html) => $(sel).html(html)),
+  trace: curry((tag, x) => { console.log(tag, x); return x; }),
+};
 
+const host = 'api.flickr.com';
+const path = '/services/feeds/photos_public.gne';
+const query = t => `?tags=${t}&format=json&jsoncallback=?`;
+const url = t => `https://${host}${path}${query(t)}`;
 
+const mediaUrl = compose(prop('m'), prop('media'));
+const mediaUrls = compose(map(mediaUrl), prop('items'));
+
+const img = src => $('<img />', { src });
+
+const images = compose(map(img), mediaUrls);
+const render = compose(Impure.setHtml('#js-main'), images);
+const app = compose(Impure.getJSON(render), url);
+```
+{% endtab %}
+
+{% tab title="ts" %}
+```typescript
+import * as A from 'fp-ts/ReadonlyArray';
+import { flow } from 'fp-ts/function';
+import $ from 'jquery';
+
+const Impure = {
+  getJSON: <T>(callback: (res: T) => void) => (url: string) => {
+    $.getJSON(url, callback);
+  },
+  setHtml: (sel: string) => (html: any) => $(sel).html(html),
+  trace: (tag: string) => <T>(x: T) => {
+    console.log(tag, x);
+    return x;
+  },
+};
+
+const host = 'api.flickr.com';
+const path = '/services/feeds/photos_public.gne';
+const query = (t: string) => `?tags=${t}&format=json&jsoncallback=?`;
+const url = (t: string) => `https://${host}${path}${query(t)}`;
+
+type MediaItem = {
+  media: {
+    m: string;
+  };
+};
+
+type ApiResponse = {
+  items: MediaItem[];
+};
+
+const mediaUrl: (item: MediaItem) => string = flow(prop('media'), prop('m'));
+const mediaUrls: (res: ApiResponse) => readonly string[] = flow(prop('items'), A.map(mediaUrl));
+
+const img = (src: string) => $('<img />', { src });
+const images = flow(mediaUrls, A.map(img));
+
+const render = flow(images, Impure.setHtml('#js-main'));
+const app = flow(url, Impure.getJSON(render));
+
+app('cats');
+```
+{% endtab %}
+{% endtabs %}
 


### PR DESCRIPTION
I added a translation of the example application from chapter 6. I haven't tested if this actually works because bundling the code so it can be executed in a browser would require some additional setup in the project and I wasn't sure whether that would be worth it.

Note: The `prop` function is assumed to be imported from somewhere, when I was writing this code I had imported it from our `utils` module but I didn't think that leaving that import in the final code for the book made sense. Let me know what your thoughts are on this though